### PR TITLE
Add Pi backend with RPC bridge

### DIFF
--- a/ipyai/backends.py
+++ b/ipyai/backends.py
@@ -3,13 +3,15 @@ from dataclasses import dataclass
 from .api_client import ClaudeAPIBackend
 from .claude_client import ClaudeSDKBackend
 from .codex_client import CodexBackend
+from .pi_client import PiBackend
 
 BACKEND_CLAUDE_SDK = "claude-sdk"
 BACKEND_CLAUDE_API = "claude-api"
 BACKEND_CODEX = "codex"
+BACKEND_PI = "pi"
 DEFAULT_BACKEND = BACKEND_CLAUDE_SDK
 BACKEND_ALIASES = {"claude": BACKEND_CLAUDE_SDK, "sdk": BACKEND_CLAUDE_SDK, "agent": BACKEND_CLAUDE_SDK, "claude-sdk": BACKEND_CLAUDE_SDK,
-    "api": BACKEND_CLAUDE_API, "claude-api": BACKEND_CLAUDE_API, "codex": BACKEND_CODEX}
+    "api": BACKEND_CLAUDE_API, "claude-api": BACKEND_CLAUDE_API, "codex": BACKEND_CODEX, "pi": BACKEND_PI, "pi-rpc": BACKEND_PI}
 
 
 @dataclass(frozen=True)
@@ -23,7 +25,8 @@ class BackendSpec:
 
 BACKENDS = {BACKEND_CLAUDE_SDK: BackendSpec(BACKEND_CLAUDE_SDK, "Claude Agent SDK", ClaudeSDKBackend, "sonnet", "haiku"),
     BACKEND_CLAUDE_API: BackendSpec(BACKEND_CLAUDE_API, "Claude API", ClaudeAPIBackend, "claude-sonnet-4-6", "claude-haiku-4-5-20251001"),
-    BACKEND_CODEX: BackendSpec(BACKEND_CODEX, "Codex", CodexBackend, "gpt-5.4", "gpt-5.4-mini")}
+    BACKEND_CODEX: BackendSpec(BACKEND_CODEX, "Codex", CodexBackend, "gpt-5.4", "gpt-5.4-mini"),
+    BACKEND_PI: BackendSpec(BACKEND_PI, "Pi RPC", PiBackend, "opencode-go/kimi-k2.5", "opencode-go/qwen3.5-plus")}
 
 
 def normalize_backend_name(name=None):

--- a/ipyai/cli.py
+++ b/ipyai/cli.py
@@ -9,7 +9,7 @@ AI-powered IPython shell
 
 options:
   -h, --help  show this help message and exit
-  -b BACKEND  backend: claude-sdk (default), claude-api, codex
+  -b BACKEND  backend: claude-sdk (default), claude-api, codex, pi
   -r [ID]     resume session (no ID = pick from list)
   -l FILE     load notebook (.ipynb)
   -p          start in prompt mode"""

--- a/ipyai/extensions/ipyai-bridge.ts
+++ b/ipyai/extensions/ipyai-bridge.ts
@@ -54,35 +54,64 @@ export default function ipyaiBridge(pi: ExtensionAPI) {
     return Type.Unsafe(schema);
   };
 
-  const registerTools = (tools: BridgeTool[]) => {
-    for (const tool of tools) {
-      if (!tool?.name || registered.has(tool.name)) continue;
-      registered.add(tool.name);
-      const parameters = wrapParameters(tool.parameters);
-      pi.registerTool({
-        name: tool.name,
-        label: tool.name,
-        description: tool.description || `Call Python tool ${tool.name}`,
-        parameters,
-        async execute(_toolCallId, params) {
-          const id = randomUUID();
-          const resultPromise = new Promise<any>((resolve, reject) => {
-            const timer = setTimeout(() => {
-              pending.delete(id);
-              reject(new Error(`Tool call timed out: ${tool.name}`));
-            }, TIMEOUT_MS);
-            pending.set(id, { resolve, reject, timer });
-          });
-          send({ type: "tool_call", id, name: tool.name, args: params || {} });
-          const result = await resultPromise;
-          return {
-            content: Array.isArray(result?.content) ? result.content : [{ type: "text", text: String(result?.error || "") }],
-            details: result?.details,
-            isError: Boolean(result?.isError),
-          };
-        },
-      });
+  const ensureActiveTools = (toolNames: string[]) => {
+    if (toolNames.length === 0) return;
+    const active = new Set(pi.getActiveTools());
+    let changed = false;
+    for (const name of toolNames) {
+      if (!active.has(name)) {
+        active.add(name);
+        changed = true;
+      }
     }
+    if (changed) pi.setActiveTools([...active]);
+  };
+
+  const registerTools = (tools: BridgeTool[]) => {
+    const successful: string[] = [];
+
+    for (const tool of tools) {
+      if (!tool?.name) continue;
+
+      if (!registered.has(tool.name)) {
+        try {
+          const parameters = wrapParameters(tool.parameters);
+          pi.registerTool({
+            name: tool.name,
+            label: tool.name,
+            description: tool.description || `Call Python tool ${tool.name}`,
+            parameters,
+            async execute(_toolCallId, params) {
+              const id = randomUUID();
+              const resultPromise = new Promise<any>((resolve, reject) => {
+                const timer = setTimeout(() => {
+                  pending.delete(id);
+                  reject(new Error(`Tool call timed out: ${tool.name}`));
+                }, TIMEOUT_MS);
+                pending.set(id, { resolve, reject, timer });
+              });
+              send({ type: "tool_call", id, name: tool.name, args: params || {} });
+              const result = await resultPromise;
+              return {
+                content: Array.isArray(result?.content) ? result.content : [{ type: "text", text: String(result?.error || "") }],
+                details: result?.details,
+                isError: Boolean(result?.isError),
+              };
+            },
+          });
+          registered.add(tool.name);
+        } catch (error) {
+          console.error(`ipyai bridge: failed to register tool ${tool.name}:`, error);
+          continue;
+        }
+      }
+
+      successful.push(tool.name);
+    }
+
+    // In pi --no-tools mode, dynamic post-start registrations only auto-activate
+    // truly new names. Overridden built-in names like "bash" must be activated explicitly.
+    ensureActiveTools(successful);
   };
 
   const handleMessage = (msg: any) => {

--- a/ipyai/extensions/ipyai-bridge.ts
+++ b/ipyai/extensions/ipyai-bridge.ts
@@ -1,0 +1,115 @@
+import net from "node:net";
+import { randomUUID } from "node:crypto";
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { Type } from "@sinclair/typebox";
+
+type BridgeTool = { name: string; description?: string; parameters?: any };
+type Pending = { resolve: (value: any) => void; reject: (error: Error) => void; timer?: ReturnType<typeof setTimeout> };
+
+const SOCKET_PATH = process.env.IPYAI_PI_TOOL_SOCKET;
+const TIMEOUT_MS = Number(process.env.IPYAI_PI_TOOL_TIMEOUT_MS || 120000);
+
+export default function ipyaiBridge(pi: ExtensionAPI) {
+  if (!SOCKET_PATH) return;
+
+  const pending = new Map<string, Pending>();
+  const registered = new Set<string>();
+  let socket: net.Socket | null = null;
+  let buffer = "";
+
+  const rejectAll = (message: string) => {
+    const err = new Error(message);
+    for (const [id, item] of pending.entries()) {
+      if (item.timer) clearTimeout(item.timer);
+      item.reject(err);
+      pending.delete(id);
+    }
+  };
+
+  const send = (obj: any) => {
+    if (!socket || socket.destroyed) throw new Error("ipyai bridge socket is not connected");
+    socket.write(JSON.stringify(obj) + "\n");
+  };
+
+  const parseLines = (chunk: Buffer | string) => {
+    buffer += typeof chunk === "string" ? chunk : chunk.toString("utf8");
+    while (true) {
+      const idx = buffer.indexOf("\n");
+      if (idx === -1) break;
+      let line = buffer.slice(0, idx);
+      buffer = buffer.slice(idx + 1);
+      if (line.endsWith("\r")) line = line.slice(0, -1);
+      if (!line.trim()) continue;
+      try {
+        const msg = JSON.parse(line);
+        handleMessage(msg);
+      } catch {
+        continue;
+      }
+    }
+  };
+
+  const wrapParameters = (schema: any) => {
+    if (!schema || typeof schema !== "object") return Type.Object({});
+    return Type.Unsafe(schema);
+  };
+
+  const registerTools = (tools: BridgeTool[]) => {
+    for (const tool of tools) {
+      if (!tool?.name || registered.has(tool.name)) continue;
+      registered.add(tool.name);
+      const parameters = wrapParameters(tool.parameters);
+      pi.registerTool({
+        name: tool.name,
+        label: tool.name,
+        description: tool.description || `Call Python tool ${tool.name}`,
+        parameters,
+        async execute(_toolCallId, params) {
+          const id = randomUUID();
+          const resultPromise = new Promise<any>((resolve, reject) => {
+            const timer = setTimeout(() => {
+              pending.delete(id);
+              reject(new Error(`Tool call timed out: ${tool.name}`));
+            }, TIMEOUT_MS);
+            pending.set(id, { resolve, reject, timer });
+          });
+          send({ type: "tool_call", id, name: tool.name, args: params || {} });
+          const result = await resultPromise;
+          return {
+            content: Array.isArray(result?.content) ? result.content : [{ type: "text", text: String(result?.error || "") }],
+            details: result?.details,
+            isError: Boolean(result?.isError),
+          };
+        },
+      });
+    }
+  };
+
+  const handleMessage = (msg: any) => {
+    if (msg?.type === "register_tools") {
+      registerTools(Array.isArray(msg.tools) ? msg.tools : []);
+      return;
+    }
+    if (msg?.type === "tool_result" && msg.id) {
+      const item = pending.get(msg.id);
+      if (!item) return;
+      pending.delete(msg.id);
+      if (item.timer) clearTimeout(item.timer);
+      item.resolve(msg);
+    }
+  };
+
+  pi.on("session_start", () => {
+    if (socket && !socket.destroyed) return;
+    socket = net.createConnection(SOCKET_PATH);
+    socket.on("data", parseLines);
+    socket.on("error", () => rejectAll("ipyai bridge socket error"));
+    socket.on("close", () => rejectAll("ipyai bridge socket closed"));
+  });
+
+  pi.on("session_shutdown", () => {
+    rejectAll("session shutdown");
+    if (socket && !socket.destroyed) socket.destroy();
+    socket = null;
+  });
+}

--- a/ipyai/pi_client.py
+++ b/ipyai/pi_client.py
@@ -1,0 +1,295 @@
+import asyncio, json, os, shlex, tempfile
+from pathlib import Path
+
+from .backend_common import BaseBackend, CommonStreamFormatter, ConversationSeed, effort_level as _effort, seed_to_notebook_xml
+from .tooling import call_ns_tool
+
+
+def _json(obj): return json.dumps(obj, ensure_ascii=False, default=str)
+
+
+async def _read_json_lines(reader):
+    """Yield parsed JSON dicts from an async line-delimited stream."""
+    while True:
+        raw = await reader.readline()
+        if not raw:
+            return
+        line = raw.decode("utf-8", errors="replace").rstrip("\n\r")
+        if not line:
+            continue
+        try:
+            yield json.loads(line)
+        except Exception:
+            continue
+
+
+
+def _pi_cmd(model, *, session=None, ephemeral=False, system_prompt="", extension=None, tool_mode="on"):
+    raw = os.environ.get("IPYAI_PI_CMD", "pi")
+    cmd = [*shlex.split(raw), "--mode", "rpc"]
+    if model: cmd += ["--model", model]
+    if system_prompt: cmd += ["--system-prompt", system_prompt]
+    if ephemeral: cmd += ["--no-session"]
+    elif session: cmd += ["--session", session]
+    # ipyai controls tool exposure via the Python bridge; keep pi built-ins disabled for parity across backends.
+    cmd += ["--no-tools"]
+    if extension:
+        cmd += ["--no-extensions", "--no-skills", "--no-prompt-templates", "--no-themes", "-e", extension]
+    return cmd
+
+
+def _content_text(content):
+    if isinstance(content, str): return content
+    if not isinstance(content, list): return ""
+    parts = []
+    for o in content:
+        if not isinstance(o, dict): continue
+        if o.get("type") == "text": parts.append(o.get("text", ""))
+    return "".join(parts)
+
+
+def _partial_text(partial):
+    if not isinstance(partial, dict): return ""
+    return _content_text(partial.get("content"))
+
+
+def _is_shell_tool(name): return name == "bash"
+
+
+def _seed_prompt(seed):
+    text = seed_to_notebook_xml(seed)
+    return text + "The XML above describes a notebook already loaded into the live IPython session. Treat it as prior session context for this thread. Reply with ok and nothing else."
+
+
+class _PiRpcProcess:
+    def __init__(self, cmd, env=None, cwd=None):
+        self.cmd,self.env,self.cwd = cmd,env,cwd
+        self.proc = None
+        self.pending = {}
+        self.events = asyncio.Queue()
+        self.read_task = self.err_task = None
+        self.req_id = 0
+
+    async def start(self):
+        if self.proc and self.proc.returncode is None: return
+        self.proc = await asyncio.create_subprocess_exec(*self.cmd, stdin=asyncio.subprocess.PIPE, stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE, cwd=self.cwd, env=self.env, start_new_session=True)
+        self.pending = {}
+        self.events = asyncio.Queue()
+        self.read_task = asyncio.create_task(self._read_stdout())
+        self.err_task = asyncio.create_task(self._drain_stderr())
+
+    async def _drain_stderr(self):
+        while self.proc and self.proc.stderr:
+            if not await self.proc.stderr.readline(): break
+
+    async def _read_stdout(self):
+        try:
+            async for msg in _read_json_lines(self.proc.stdout):
+                if msg.get("type") == "response" and msg.get("id") in self.pending:
+                    fut = self.pending.pop(msg["id"], None)
+                    if fut and not fut.done(): fut.set_result(msg)
+                else: await self.events.put(msg)
+        finally:
+            err = RuntimeError("pi rpc process exited")
+            for fut in self.pending.values():
+                if not fut.done(): fut.set_exception(err)
+            self.pending.clear()
+            await self.events.put(None)
+
+    async def _send(self, msg):
+        await self.start()
+        self.proc.stdin.write((_json(msg) + "\n").encode())
+        await self.proc.stdin.drain()
+
+    async def request(self, typ, **kwargs):
+        self.req_id += 1
+        rid = str(self.req_id)
+        fut = asyncio.get_running_loop().create_future()
+        self.pending[rid] = fut
+        await self._send(dict(id=rid, type=typ, **kwargs))
+        msg = await fut
+        if not msg.get("success", False): raise RuntimeError(msg.get("error") or f"pi rpc {typ} failed")
+        return msg
+
+    async def abort(self):
+        try: await self.request("abort")
+        except Exception: pass
+
+    async def close(self):
+        if self.proc and self.proc.returncode is None:
+            try:
+                self.proc.terminate()
+                await asyncio.wait_for(self.proc.wait(), timeout=2)
+            except Exception:
+                self.proc.kill()
+        for t in (self.read_task, self.err_task):
+            if t and not t.done(): t.cancel()
+
+
+class PiToolBridge:
+    def __init__(self, tools):
+        self.tools = tools
+        self.server = None
+        self.writer = None
+        self.tasks = set()
+        self.tmpdir = None
+        self.socket_path = None
+
+    @property
+    def env(self): return {} if not self.socket_path else {"IPYAI_PI_TOOL_SOCKET": self.socket_path}
+
+    def payload(self):
+        tools = []
+        for o in self.tools.openai_schemas():
+            fn = o.get("function") or {}
+            tools.append(dict(name=fn.get("name") or "", description=fn.get("description") or "", parameters=fn.get("parameters") or dict(type="object")))
+        return dict(type="register_tools", tools=[o for o in tools if o["name"]])
+
+    async def start(self):
+        if self.server is not None: return
+        self.tmpdir = tempfile.TemporaryDirectory(prefix="ipyai-pi-")
+        self.socket_path = str(Path(self.tmpdir.name) / "tool-bridge.sock")
+        self.server = await asyncio.start_unix_server(self._handle_client, path=self.socket_path)
+
+    async def _handle_client(self, reader, writer):
+        self.writer = writer
+        writer.write((_json(self.payload()) + "\n").encode())
+        await writer.drain()
+        try:
+            async for msg in _read_json_lines(reader):
+                task = asyncio.create_task(self._handle_message(msg, writer))
+                self.tasks.add(task)
+                task.add_done_callback(self.tasks.discard)
+        finally:
+            if self.writer is writer: self.writer = None
+            writer.close()
+            await writer.wait_closed()
+
+    async def _handle_message(self, msg, writer):
+        if msg.get("type") != "tool_call": return
+        rid,name,args = msg.get("id"),msg.get("name"),msg.get("args") or {}
+        try:
+            text = await call_ns_tool(self.tools.ns, name, args)
+            result = dict(type="tool_result", id=rid, isError=False, content=[dict(type="text", text=text)])
+        except Exception as e:
+            result = dict(type="tool_result", id=rid, isError=True, content=[dict(type="text", text=f"Error: {e}")])
+        writer.write((_json(result) + "\n").encode())
+        await writer.drain()
+
+    async def close(self):
+        for t in list(self.tasks):
+            if not t.done(): t.cancel()
+        if self.writer:
+            self.writer.close()
+            await self.writer.wait_closed()
+            self.writer = None
+        if self.server:
+            self.server.close()
+            await self.server.wait_closed()
+            self.server = None
+        if self.tmpdir:
+            self.tmpdir.cleanup()
+            self.tmpdir = None
+            self.socket_path = None
+
+
+class PiBackend(BaseBackend):
+    formatter_cls = CommonStreamFormatter
+
+    async def _stream_prompt(self, proc, prompt):
+        await proc.request("prompt", message=prompt)
+        tool_meta,last_partial = {},{}
+        while True:
+            msg = await proc.events.get()
+            if msg is None: break
+            typ = msg.get("type")
+            if typ == "agent_end": break
+            if typ == "message_update":
+                event = msg.get("assistantMessageEvent") or {}
+                etyp = event.get("type")
+                if etyp == "text_delta":
+                    if (delta := event.get("delta", "")): yield delta
+                elif etyp == "thinking_start": yield dict(kind="thinking_start")
+                elif etyp == "thinking_delta": yield dict(kind="thinking_delta", delta=event.get("delta", ""))
+                elif etyp == "thinking_end": yield dict(kind="thinking_end")
+                continue
+            if typ == "tool_execution_start":
+                tool_id,name,args = msg["toolCallId"],msg["toolName"],msg["args"]
+                tool_meta[tool_id] = dict(name=name, args=args)
+                last_partial[tool_id] = ""
+                if _is_shell_tool(name):
+                    yield dict(kind="command_start", id=tool_id, command=args.get("command"), cwd=self.ctx.cwd)
+                else: yield dict(kind="tool_start", id=tool_id, name=name, input=args)
+                continue
+            if typ == "tool_execution_update":
+                tool_id,name,args = msg["toolCallId"],msg["toolName"],msg["args"]
+                if not _is_shell_tool(name): continue
+                text = _partial_text(msg["partialResult"])
+                prev = last_partial.get(tool_id, "")
+                delta = text[len(prev):] if text.startswith(prev) else text
+                last_partial[tool_id] = text
+                if delta: yield dict(kind="command_delta", id=tool_id, delta=delta, command=args.get("command"), cwd=self.ctx.cwd)
+                continue
+            if typ == "tool_execution_end":
+                tool_id,name = msg["toolCallId"],msg["toolName"]
+                meta,args = tool_meta[tool_id],tool_meta[tool_id]["args"]
+                result = msg["result"]
+                content = _content_text(result["content"])
+                if _is_shell_tool(name):
+                    yield dict(kind="command_complete", id=tool_id, command=args.get("command"),
+                        output=content or last_partial.get(tool_id, ""), exit_code=result["details"].get("exitCode"))
+                else:
+                    yield dict(kind="tool_complete", id=tool_id, name=meta["name"], input=args, content=content,
+                        is_error=msg["isError"])
+                continue
+
+    async def _run_attempt(self, *, prompt, model, think, seed, tool_mode, ephemeral, session_path, state):
+        bridge = None
+        if tool_mode != "off" and self.tools.names():
+            bridge = PiToolBridge(self.tools)
+            await bridge.start()
+
+        extension = str(Path(__file__).resolve().parent / "extensions" / "ipyai-bridge.ts") if bridge else None
+        env = os.environ.copy()
+        if bridge: env.update(bridge.env)
+        cmd = _pi_cmd(model, session=session_path, ephemeral=ephemeral, system_prompt=self.ctx.system_prompt, extension=extension, tool_mode=tool_mode)
+        proc = _PiRpcProcess(cmd, env=env, cwd=self.ctx.cwd)
+        aborted = False
+        try:
+            await proc.start()
+            await proc.request("set_thinking_level", level=_effort(think))
+            if not session_path and seed.startup_events:
+                async for _ in self._stream_prompt(proc, _seed_prompt(seed)): pass
+            async for o in self._stream_prompt(proc, prompt): yield o
+            data = (await proc.request("get_state")).get("data") or {}
+            if (session_file := data.get("sessionFile")): state["provider_session_id"] = session_file
+        except (asyncio.CancelledError, GeneratorExit):
+            aborted = True
+            await proc.abort()
+            raise
+        finally:
+            if not aborted: await proc.abort()
+            await proc.close()
+            if bridge: await bridge.close()
+
+    async def prepare_turn(self, *, prompt, model, think="l", provider_session_id=None, seed=None, tool_mode="on", ephemeral=False):
+        seed = seed or ConversationSeed()
+        state = {}
+
+        async def _stream():
+            attempts = [provider_session_id] if provider_session_id or ephemeral else [None]
+            if provider_session_id and not ephemeral: attempts.append(None)
+            last = None
+            for i,session_path in enumerate(attempts):
+                try:
+                    async for o in self._run_attempt(prompt=prompt, model=model, think=think, seed=seed, tool_mode=tool_mode, ephemeral=ephemeral,
+                        session_path=session_path, state=state):
+                        yield o
+                    return
+                except Exception as e:
+                    last = e
+                    if i == len(attempts)-1: raise
+            if last: raise last
+
+        return self.prepared_turn(_stream(), provider_session_id=provider_session_id, state=state)

--- a/ipyai/pi_client.py
+++ b/ipyai/pi_client.py
@@ -1,4 +1,4 @@
-import asyncio, json, os, shlex, tempfile
+import asyncio, atexit, json, os, shlex, signal, tempfile
 from pathlib import Path
 
 from .backend_common import BaseBackend, CommonStreamFormatter, ConversationSeed, effort_level as _effort, seed_to_notebook_xml
@@ -24,13 +24,12 @@ async def _read_json_lines(reader):
 
 
 
-def _pi_cmd(model, *, session=None, ephemeral=False, system_prompt="", extension=None, tool_mode="on"):
+def _pi_cmd(model, *, session=None, system_prompt="", extension=None, tool_mode="on"):
     raw = os.environ.get("IPYAI_PI_CMD", "pi")
     cmd = [*shlex.split(raw), "--mode", "rpc"]
     if model: cmd += ["--model", model]
     if system_prompt: cmd += ["--system-prompt", system_prompt]
-    if ephemeral: cmd += ["--no-session"]
-    elif session: cmd += ["--session", session]
+    if session: cmd += ["--session", session]
     # ipyai controls tool exposure via the Python bridge; keep pi built-ins disabled for parity across backends.
     cmd += ["--no-tools"]
     if extension:
@@ -59,6 +58,53 @@ def _is_shell_tool(name): return name == "bash"
 def _seed_prompt(seed):
     text = seed_to_notebook_xml(seed)
     return text + "The XML above describes a notebook already loaded into the live IPython session. Treat it as prior session context for this thread. Reply with ok and nothing else."
+
+
+async def _consume_turn(proc, *, cwd):
+    tool_meta,last_partial = {},{}
+    while True:
+        msg = await proc.events.get()
+        if msg is None: break
+        typ = msg.get("type")
+        if typ == "agent_end": break
+        if typ == "message_update":
+            event = msg.get("assistantMessageEvent") or {}
+            etyp = event.get("type")
+            if etyp == "text_delta":
+                if (delta := event.get("delta", "")): yield delta
+            elif etyp == "thinking_start": yield dict(kind="thinking_start")
+            elif etyp == "thinking_delta": yield dict(kind="thinking_delta", delta=event.get("delta", ""))
+            elif etyp == "thinking_end": yield dict(kind="thinking_end")
+            continue
+        if typ == "tool_execution_start":
+            tool_id,name,args = msg["toolCallId"],msg["toolName"],msg["args"]
+            tool_meta[tool_id] = dict(name=name, args=args)
+            last_partial[tool_id] = ""
+            if _is_shell_tool(name):
+                yield dict(kind="command_start", id=tool_id, command=args.get("command"), cwd=cwd)
+            else: yield dict(kind="tool_start", id=tool_id, name=name, input=args)
+            continue
+        if typ == "tool_execution_update":
+            tool_id,name,args = msg["toolCallId"],msg["toolName"],msg["args"]
+            if not _is_shell_tool(name): continue
+            text = _partial_text(msg["partialResult"])
+            prev = last_partial.get(tool_id, "")
+            delta = text[len(prev):] if text.startswith(prev) else text
+            last_partial[tool_id] = text
+            if delta: yield dict(kind="command_delta", id=tool_id, delta=delta, command=args.get("command"), cwd=cwd)
+            continue
+        if typ == "tool_execution_end":
+            tool_id,name = msg["toolCallId"],msg["toolName"]
+            meta,args = tool_meta[tool_id],tool_meta[tool_id]["args"]
+            result = msg["result"]
+            content = _content_text(result["content"])
+            if _is_shell_tool(name):
+                yield dict(kind="command_complete", id=tool_id, command=args.get("command"),
+                    output=content or last_partial.get(tool_id, ""), exit_code=(result.get("details") or {}).get("exitCode"))
+            else:
+                yield dict(kind="tool_complete", id=tool_id, name=meta["name"], input=args, content=content,
+                    is_error=msg["isError"])
+            continue
 
 
 class _PiRpcProcess:
@@ -125,6 +171,7 @@ class _PiRpcProcess:
                 self.proc.kill()
         for t in (self.read_task, self.err_task):
             if t and not t.done(): t.cancel()
+        self.proc = None
 
 
 class PiToolBridge:
@@ -151,6 +198,11 @@ class PiToolBridge:
         self.tmpdir = tempfile.TemporaryDirectory(prefix="ipyai-pi-")
         self.socket_path = str(Path(self.tmpdir.name) / "tool-bridge.sock")
         self.server = await asyncio.start_unix_server(self._handle_client, path=self.socket_path)
+
+    async def refresh(self):
+        if not self.writer: return
+        self.writer.write((_json(self.payload()) + "\n").encode())
+        await self.writer.drain()
 
     async def _handle_client(self, reader, writer):
         self.writer = writer
@@ -194,102 +246,169 @@ class PiToolBridge:
             self.socket_path = None
 
 
+class _PiProcessManager:
+    def __init__(self, *, cwd=None, system_prompt=""):
+        self.cwd = cwd or os.getcwd()
+        self.system_prompt = system_prompt
+        self.model = None
+        self.proc = None
+        self.bridge = None
+        self.turn_lock = asyncio.Lock()
+        self.start_lock = asyncio.Lock()
+        self.active_session_file = None
+        self.extension = str(Path(__file__).resolve().parent / "extensions" / "ipyai-bridge.ts")
+
+    def _bridge_enabled(self, *, tool_mode="on", tools=None):
+        return tool_mode != "off" and bool(tools and tools.names())
+
+    async def ensure_started(self, *, model, tools, tool_mode="on", cwd=None, system_prompt=None):
+        async with self.start_lock:
+            if self.proc and self.proc.proc and self.proc.proc.returncode is None:
+                if self.bridge:
+                    self.bridge.tools = tools
+                    await self.bridge.refresh()
+                return
+            await self.close()
+            self.cwd = cwd or self.cwd
+            self.system_prompt = system_prompt or self.system_prompt
+            self.model = model
+            env = os.environ.copy()
+            extension = None
+            if self._bridge_enabled(tool_mode=tool_mode, tools=tools):
+                self.bridge = PiToolBridge(tools)
+                await self.bridge.start()
+                env.update(self.bridge.env)
+                extension = self.extension
+            cmd = _pi_cmd(model, system_prompt=self.system_prompt, extension=extension, tool_mode=tool_mode)
+            self.proc = _PiRpcProcess(cmd, env=env, cwd=self.cwd)
+            await self.proc.start()
+            self.active_session_file = None
+
+    async def start_session(self, *, model, think="l", tools=None, tool_mode="on", cwd=None, system_prompt=None):
+        await self.ensure_started(model=model, tools=tools, tool_mode=tool_mode, cwd=cwd, system_prompt=system_prompt)
+        if self.bridge:
+            self.bridge.tools = tools
+            await self.bridge.refresh()
+        await self.proc.request("set_thinking_level", level=_effort(think))
+        result = await self.proc.request("new_session")
+        data = result.get("data") or {}
+        if data.get("cancelled"):
+            raise RuntimeError("pi rpc new_session cancelled")
+        data = (await self.proc.request("get_state")).get("data") or {}
+        self.active_session_file = data.get("sessionFile")
+        if not self.active_session_file:
+            raise RuntimeError("pi rpc new_session did not produce a sessionFile")
+        return self.active_session_file
+
+    async def resume_session(self, provider_session_id, *, model, think="l", tools=None, tool_mode="on", cwd=None, system_prompt=None):
+        await self.ensure_started(model=model, tools=tools, tool_mode=tool_mode, cwd=cwd, system_prompt=system_prompt)
+        if self.bridge:
+            self.bridge.tools = tools
+            await self.bridge.refresh()
+        await self.proc.request("set_thinking_level", level=_effort(think))
+        if provider_session_id != self.active_session_file:
+            result = await self.proc.request("switch_session", sessionPath=provider_session_id)
+            data = result.get("data") or {}
+            if data.get("cancelled"):
+                raise RuntimeError(f"pi rpc switch_session cancelled for {provider_session_id}")
+            self.active_session_file = provider_session_id
+        return provider_session_id
+
+    async def seed_session(self, seed, *, think="l", tools=None):
+        if not seed.startup_events: return
+        async with self.turn_lock:
+            if self.bridge:
+                self.bridge.tools = tools
+                await self.bridge.refresh()
+            await self.proc.request("set_thinking_level", level=_effort(think))
+            await self.proc.request("prompt", message=_seed_prompt(seed))
+            async for _ in _consume_turn(self.proc, cwd=self.cwd): pass
+
+    async def turn_stream(self, prompt, *, think="l", tools=None):
+        async with self.turn_lock:
+            if self.bridge:
+                self.bridge.tools = tools
+                await self.bridge.refresh()
+            await self.proc.request("set_thinking_level", level=_effort(think))
+            await self.proc.request("prompt", message=prompt)
+            async for o in _consume_turn(self.proc, cwd=self.cwd):
+                yield o
+            data = (await self.proc.request("get_state")).get("data") or {}
+            if (session_file := data.get("sessionFile")):
+                self.active_session_file = session_file
+
+    async def abort(self):
+        if self.proc: await self.proc.abort()
+
+    def _sync_close(self):
+        """Synchronous cleanup for atexit — no event loop guaranteed."""
+        if self.proc and self.proc.proc and self.proc.proc.returncode is None:
+            try:
+                self.proc.proc.send_signal(signal.SIGTERM)
+            except Exception:
+                pass
+        if self.bridge and self.bridge.tmpdir:
+            try:
+                self.bridge.tmpdir.cleanup()
+            except Exception:
+                pass
+
+    async def close(self):
+        if self.proc:
+            await self.proc.close()
+            self.proc = None
+        if self.bridge:
+            await self.bridge.close()
+            self.bridge = None
+        self.active_session_file = None
+
+
+_manager = None
+
+
+def get_pi_process_manager(*, cwd=None, system_prompt=""):
+    global _manager
+    if _manager is None:
+        _manager = _PiProcessManager(cwd=cwd, system_prompt=system_prompt)
+    return _manager
+
+
+def _cleanup_pi_process():
+    global _manager
+    if _manager is not None:
+        _manager._sync_close()
+        _manager = None
+
+
+atexit.register(_cleanup_pi_process)
+
+
 class PiBackend(BaseBackend):
     formatter_cls = CommonStreamFormatter
-
-    async def _stream_prompt(self, proc, prompt):
-        await proc.request("prompt", message=prompt)
-        tool_meta,last_partial = {},{}
-        while True:
-            msg = await proc.events.get()
-            if msg is None: break
-            typ = msg.get("type")
-            if typ == "agent_end": break
-            if typ == "message_update":
-                event = msg.get("assistantMessageEvent") or {}
-                etyp = event.get("type")
-                if etyp == "text_delta":
-                    if (delta := event.get("delta", "")): yield delta
-                elif etyp == "thinking_start": yield dict(kind="thinking_start")
-                elif etyp == "thinking_delta": yield dict(kind="thinking_delta", delta=event.get("delta", ""))
-                elif etyp == "thinking_end": yield dict(kind="thinking_end")
-                continue
-            if typ == "tool_execution_start":
-                tool_id,name,args = msg["toolCallId"],msg["toolName"],msg["args"]
-                tool_meta[tool_id] = dict(name=name, args=args)
-                last_partial[tool_id] = ""
-                if _is_shell_tool(name):
-                    yield dict(kind="command_start", id=tool_id, command=args.get("command"), cwd=self.ctx.cwd)
-                else: yield dict(kind="tool_start", id=tool_id, name=name, input=args)
-                continue
-            if typ == "tool_execution_update":
-                tool_id,name,args = msg["toolCallId"],msg["toolName"],msg["args"]
-                if not _is_shell_tool(name): continue
-                text = _partial_text(msg["partialResult"])
-                prev = last_partial.get(tool_id, "")
-                delta = text[len(prev):] if text.startswith(prev) else text
-                last_partial[tool_id] = text
-                if delta: yield dict(kind="command_delta", id=tool_id, delta=delta, command=args.get("command"), cwd=self.ctx.cwd)
-                continue
-            if typ == "tool_execution_end":
-                tool_id,name = msg["toolCallId"],msg["toolName"]
-                meta,args = tool_meta[tool_id],tool_meta[tool_id]["args"]
-                result = msg["result"]
-                content = _content_text(result["content"])
-                if _is_shell_tool(name):
-                    yield dict(kind="command_complete", id=tool_id, command=args.get("command"),
-                        output=content or last_partial.get(tool_id, ""), exit_code=result["details"].get("exitCode"))
-                else:
-                    yield dict(kind="tool_complete", id=tool_id, name=meta["name"], input=args, content=content,
-                        is_error=msg["isError"])
-                continue
-
-    async def _run_attempt(self, *, prompt, model, think, seed, tool_mode, ephemeral, session_path, state):
-        bridge = None
-        if tool_mode != "off" and self.tools.names():
-            bridge = PiToolBridge(self.tools)
-            await bridge.start()
-
-        extension = str(Path(__file__).resolve().parent / "extensions" / "ipyai-bridge.ts") if bridge else None
-        env = os.environ.copy()
-        if bridge: env.update(bridge.env)
-        cmd = _pi_cmd(model, session=session_path, ephemeral=ephemeral, system_prompt=self.ctx.system_prompt, extension=extension, tool_mode=tool_mode)
-        proc = _PiRpcProcess(cmd, env=env, cwd=self.ctx.cwd)
-        aborted = False
-        try:
-            await proc.start()
-            await proc.request("set_thinking_level", level=_effort(think))
-            if not session_path and seed.startup_events:
-                async for _ in self._stream_prompt(proc, _seed_prompt(seed)): pass
-            async for o in self._stream_prompt(proc, prompt): yield o
-            data = (await proc.request("get_state")).get("data") or {}
-            if (session_file := data.get("sessionFile")): state["provider_session_id"] = session_file
-        except (asyncio.CancelledError, GeneratorExit):
-            aborted = True
-            await proc.abort()
-            raise
-        finally:
-            if not aborted: await proc.abort()
-            await proc.close()
-            if bridge: await bridge.close()
 
     async def prepare_turn(self, *, prompt, model, think="l", provider_session_id=None, seed=None, tool_mode="on", ephemeral=False):
         seed = seed or ConversationSeed()
         state = {}
+        client = get_pi_process_manager(cwd=self.ctx.cwd, system_prompt=self.ctx.system_prompt)
+        session_id = provider_session_id
+        if session_id:
+            try:
+                session_id = await client.resume_session(session_id, model=model, think=think, tools=self.tools,
+                    tool_mode=tool_mode, cwd=self.ctx.cwd, system_prompt=self.ctx.system_prompt)
+                state["provider_session_id"] = session_id
+            except Exception:
+                session_id = None
+        if not session_id:
+            session_id = await client.start_session(model=model, think=think, tools=self.tools,
+                tool_mode=tool_mode, cwd=self.ctx.cwd, system_prompt=self.ctx.system_prompt)
+            if seed.startup_events:
+                await client.seed_session(seed, think=think, tools=self.tools)
+            state["provider_session_id"] = session_id
 
-        async def _stream():
-            attempts = [provider_session_id] if provider_session_id or ephemeral else [None]
-            if provider_session_id and not ephemeral: attempts.append(None)
-            last = None
-            for i,session_path in enumerate(attempts):
-                try:
-                    async for o in self._run_attempt(prompt=prompt, model=model, think=think, seed=seed, tool_mode=tool_mode, ephemeral=ephemeral,
-                        session_path=session_path, state=state):
-                        yield o
-                    return
-                except Exception as e:
-                    last = e
-                    if i == len(attempts)-1: raise
-            if last: raise last
+        async def _stream_persistent():
+            async for o in client.turn_stream(prompt, think=think, tools=self.tools):
+                yield o
+            if client.active_session_file:
+                state["provider_session_id"] = client.active_session_file
 
-        return self.prepared_turn(_stream(), provider_session_id=provider_session_id, state=state)
+        return self.prepared_turn(_stream_persistent(), provider_session_id=session_id, state=state)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,9 @@ version = {attr = "ipyai.__version__"}
 [tool.setuptools.packages.find]
 include = ["ipyai*"]
 
+[tool.setuptools.package-data]
+ipyai = ["extensions/*.ts"]
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 asyncio_mode = "auto"

--- a/tests/test_backend_pi.py
+++ b/tests/test_backend_pi.py
@@ -1,0 +1,11 @@
+import asyncio, shutil
+
+import pytest
+
+from ipyai.backends import BACKEND_PI
+from tests.test_backends import _run_roundtrip
+
+
+def test_pi_backend_roundtrip(shell, tmp_path):
+    if shutil.which("pi") is None: pytest.skip("pi CLI is not available")
+    asyncio.run(_run_roundtrip(type(shell), tmp_path, BACKEND_PI))

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -2,13 +2,14 @@ import json, re
 
 from safepyrun import RunPython
 
-from ipyai.backends import BACKEND_CLAUDE_API, BACKEND_CLAUDE_SDK
+from ipyai.backends import BACKEND_CLAUDE_API, BACKEND_CLAUDE_SDK, BACKEND_PI
 from ipyai.core import IPyAIExtension, LAST_RESPONSE
 
 
 def _backend_model(backend_name):
     if backend_name == BACKEND_CLAUDE_SDK: return "haiku"
     if backend_name == BACKEND_CLAUDE_API: return "claude-haiku-4-5-20251001"
+    if backend_name == BACKEND_PI: return "opencode-go/qwen3.5-plus"
     return "gpt-5.4-mini"
 
 

--- a/tests/test_pi_client.py
+++ b/tests/test_pi_client.py
@@ -1,0 +1,56 @@
+import asyncio
+
+import ipyai.pi_client as pc
+
+
+class FakeProc:
+    def __init__(self, events):
+        self.events = asyncio.Queue()
+        for o in events: self.events.put_nowait(o)
+
+    async def request(self, *_args, **_kwargs):
+        return dict(type="response", success=True)
+
+
+async def test_stream_prompt_maps_text_thinking_and_bash_delta(shell):
+    backend = pc.PiBackend(shell=shell, system_prompt="sys")
+    events = [
+        dict(type="message_update", assistantMessageEvent=dict(type="thinking_start")),
+        dict(type="message_update", assistantMessageEvent=dict(type="thinking_delta", delta="plan")),
+        dict(type="message_update", assistantMessageEvent=dict(type="thinking_end")),
+        dict(type="message_update", assistantMessageEvent=dict(type="text_delta", delta="Hello")),
+        dict(type="tool_execution_start", toolCallId="t1", toolName="bash", args=dict(command="echo hi")),
+        dict(type="tool_execution_update", toolCallId="t1", toolName="bash", args=dict(command="echo hi"),
+            partialResult=dict(content=[dict(type="text", text="a")])) ,
+        dict(type="tool_execution_update", toolCallId="t1", toolName="bash", args=dict(command="echo hi"),
+            partialResult=dict(content=[dict(type="text", text="ab")])) ,
+        dict(type="tool_execution_end", toolCallId="t1", toolName="bash", isError=False,
+            result=dict(content=[dict(type="text", text="ab")], details=dict(exitCode=0))),
+        dict(type="agent_end"),
+    ]
+
+    out = [o async for o in backend._stream_prompt(FakeProc(events), "hi")]
+
+    assert out == [
+        dict(kind="thinking_start"),
+        dict(kind="thinking_delta", delta="plan"),
+        dict(kind="thinking_end"),
+        "Hello",
+        dict(kind="command_start", id="t1", command="echo hi", cwd=backend.ctx.cwd),
+        dict(kind="command_delta", id="t1", delta="a", command="echo hi", cwd=backend.ctx.cwd),
+        dict(kind="command_delta", id="t1", delta="b", command="echo hi", cwd=backend.ctx.cwd),
+        dict(kind="command_complete", id="t1", command="echo hi", output="ab", exit_code=0),
+    ]
+
+
+def test_pi_cmd_supports_ephemeral_and_extensions():
+    cmd = pc._pi_cmd("sonnet", session="/tmp/s.jsonl", ephemeral=False, system_prompt="sys", extension="/tmp/ext.ts", tool_mode="on")
+    assert "--mode" in cmd and "rpc" in cmd
+    assert "--session" in cmd and "/tmp/s.jsonl" in cmd
+    assert "--system-prompt" in cmd and "sys" in cmd
+    assert "-e" in cmd and "/tmp/ext.ts" in cmd
+    assert "--no-tools" in cmd
+
+    cmd2 = pc._pi_cmd("haiku", ephemeral=True, tool_mode="off")
+    assert "--no-session" in cmd2
+    assert "--no-tools" in cmd2


### PR DESCRIPTION
cc @jph00

Adds a Pi RPC backend that communicates with the `pi` CLI via its `--mode rpc` interface, along with a Unix-socket-based tool bridge extension that exposes ipyai tools to Pi as custom tools.

**Changes:**
- `ipyai/pi_client.py` — PiBackend, PiRpcProcess, and PiToolBridge
- `ipyai/extensions/ipyai-bridge.ts` — Pi extension that connects to the tool bridge socket
- `ipyai/backends.py` / `ipyai/cli.py` — register the `pi` backend
- `pyproject.toml` — include `extensions/*.ts` in package data
- Tests for the Pi backend and client