### PR TITLE
Serializing tool calls

### DIFF
--- a/ipyai/kernel_bridge.py
+++ b/ipyai/kernel_bridge.py
@@ -55,19 +55,21 @@ class KernelBridge:
         self.client = client
         self._schemas = None
         self._names = None
+        self._exec_lock = asyncio.Lock()  # shell/iopub channels are shared across all execute requests
 
     async def _exec(self, code, *, expressions=None, capture_stream=False, timeout=_EXEC_TIMEOUT):
-        msg_id = self.client.execute(code, silent=True, store_history=False, user_expressions=expressions or {})
-        stream = [] if capture_stream else None
-        iop = asyncio.create_task(_drain_iopub_until_idle(self.client, msg_id, stream, timeout=timeout))
-        reply = await _get_shell_reply(self.client, msg_id, timeout=timeout)
-        try: await iop
-        except Exception: iop.cancel()
-        content = reply["content"]
-        if content.get("status") != "ok":
-            raise RuntimeError(content.get("evalue") or content.get("ename") or "kernel execute failed")
-        exprs = {k: _expr_value(v) for k,v in (content.get("user_expressions") or {}).items()}
-        return exprs, "".join(stream) if stream is not None else ""
+        async with self._exec_lock:
+            msg_id = self.client.execute(code, silent=True, store_history=False, user_expressions=expressions or {})
+            stream = [] if capture_stream else None
+            iop = asyncio.create_task(_drain_iopub_until_idle(self.client, msg_id, stream, timeout=timeout))
+            reply = await _get_shell_reply(self.client, msg_id, timeout=timeout)
+            try: await iop
+            except Exception: iop.cancel()
+            content = reply["content"]
+            if content.get("status") != "ok":
+                raise RuntimeError(content.get("evalue") or content.get("ename") or "kernel execute failed")
+            exprs = {k: _expr_value(v) for k,v in (content.get("user_expressions") or {}).items()}
+            return exprs, "".join(stream) if stream is not None else ""
 
     async def present_names(self, names):
         "Return subset of `names` already defined and callable in the kernel's user_ns."

--- a/tests/test_kernel_dispatch.py
+++ b/tests/test_kernel_dispatch.py
@@ -45,6 +45,47 @@ def test_call_tool_uses_longer_timeout_than_probe_exec(kernel_bridge, kernel_loo
     kernel_loop.run_until_complete(_go())
 
 
+def test_exec_serializes_concurrent_requests(kernel_loop):
+    import ipyai.kernel_bridge as kb
+
+    class FakeClient:
+        def __init__(self):
+            self.shell_q = asyncio.Queue()
+            self.iopub_q = asyncio.Queue()
+            self.exec_count = 0
+            self.inflight = 0
+            self.max_inflight = 0
+
+        def execute(self, code, silent=True, store_history=False, user_expressions=None):
+            self.exec_count += 1
+            msg_id = f"msg_{self.exec_count}"
+            self.inflight += 1
+            self.max_inflight = max(self.max_inflight, self.inflight)
+
+            async def _respond():
+                await asyncio.sleep(0.01)
+                await self.shell_q.put(dict(parent_header=dict(msg_id=msg_id), content=dict(status="ok", user_expressions={})))
+                await asyncio.sleep(0.01)
+                await self.iopub_q.put(dict(parent_header=dict(msg_id=msg_id), msg_type="status",
+                    content=dict(execution_state="idle")))
+                self.inflight -= 1
+
+            asyncio.create_task(_respond())
+            return msg_id
+
+        async def get_shell_msg(self): return await self.shell_q.get()
+
+        async def get_iopub_msg(self): return await self.iopub_q.get()
+
+    async def _go():
+        client = FakeClient()
+        bridge = kb.KernelBridge(client)
+        await asyncio.gather(bridge._exec(""), bridge._exec(""))
+        assert client.max_inflight == 1, f"_exec calls must serialize on the shared kernel channels: {client.max_inflight=}"
+
+    kernel_loop.run_until_complete(_go())
+
+
 def test_bridge_preserves_full_response_from_kernel_tool(kernel_bridge, kernel_loop, monkeypatch):
     "A kernel-side tool that opts out of truncation with `FullResponse` must have its type preserved across the bridge — otherwise lisette's `_trunc_str` will truncate it on replay."
     import ipyai.kernel_bridge as kb


### PR DESCRIPTION
Lisette supports multiple tools calls in parallel. However, because of the current implementation the `_drain_iopub_until_idle` can drain the iopub of the wrong tool (as they are both queued to the kernel). In this case, it see that the message id is not its own so it ignores it

`if msg["parent_header"].get("msg_id") != msg_id: continue`

When this happens `ipyai` will hung for 10min (the tool timeout) which is not ideal.

Given that the kernel will run the tool calls sequentially in any case (if I understand it correctly) I serialized the `ipyai` tools calls with a lock. wdty?



<img width="948" height="774" alt="Screenshot 2026-04-29 at 09 32 55" src="https://github.com/user-attachments/assets/452584b6-96c3-4373-a2c8-768f7589aebc" />
