### PR TITLE
Use the message model from aidialog rather than fastllm

### DIFF
--- a/ipyai/assistant.py
+++ b/ipyai/assistant.py
@@ -6,7 +6,7 @@ formatted form. Ctx assembly is `dlg2hist` -- no hand-rolled XML -- and every mo
 fastllm `AsyncChat` built from a flat vendor-prefixed model string (e.g. 'codex/gpt-5.4')."""
 import asyncio, ast, os, re, subprocess
 from aidialog.dialog import Dialog, prompt_output
-from llmsurgery.hist import dlg2hist   # also activates the Message.to_parts/ai_output patches
+from llmsurgery.hist import dlg2hist   # also activates the Message.to_parts patch (ai_output now comes with aidialog.dialog)
 from .config import load_config, load_sysp, SUGGEST_SP
 
 LAST_PROMPT = '_ai_last_prompt'

--- a/ipyai/cli.py
+++ b/ipyai/cli.py
@@ -502,7 +502,7 @@ class App:
 
     def _replay_reply(self, response):
         "Render a stored reply through the same block machinery: fmt2hist recovers text and tool parts."
-        from fastllm.chat import fmt2hist
+        from aidialog.msg_parts import fmt2hist
         tr = TurnRenderer(self.comp, _gutter, theme=self.theme, collapse_at=self.collapse_at)
         try: msgs = fmt2hist(response)
         except Exception: msgs = None

--- a/ipyai/reply.py
+++ b/ipyai/reply.py
@@ -11,7 +11,7 @@ collapsed-by-default blocks, and a fresh partial follows."""
 import mdhtml
 from rich.text import Text
 from .mdrich import md_blocks
-from fastllm.types import Part, PartType
+from aidialog.msg_parts import Part, PartType
 
 def _trunc(v, mx=40):
     s = v if isinstance(v, str) else repr(v)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ requires-python = ">=3.10"
 license = {text = "Apache-2.0"}
 authors = [{name = "Jeremy Howard", email = "info@answer.ai"}]
 dependencies = ["fastcore>=1.12.31", "ipython>=9", "jupyter_client>=8", "teleprint", "conkernelclient", "ipymini", "rich", "mistletoe", "ipythonng", "safepyrun",
-    "python-fastllm>=0.0.32", "fastllm-claude-code", "llmsurgery", "apsw", "safecmd", "pyskills", "toolslm", "pillow"]
+    "python-fastllm>=0.0.32", "fastllm-claude-code", "llmsurgery>=0.0.8", "aidialog>=0.0.3", "apsw", "safecmd", "pyskills", "toolslm", "pillow"]
 
 [project.scripts]
 ipyai = "ipyai.cli:main"

--- a/tests/test_assistant.py
+++ b/tests/test_assistant.py
@@ -1,7 +1,7 @@
 "cp3/cp4: routing, streaming reply rendering, the assistant end-to-end over a StubChat, paste bindings, ghost text."
 import asyncio
 from rich.text import Text
-from fastllm.types import Part, PartType
+from aidialog.msg_parts import Part, PartType
 from teleprint.testing import EmuTty
 from ipyai.cli import App, _gutter
 from ipyai.reply import TurnRenderer
@@ -154,7 +154,7 @@ def test_reply_stored_in_fastllm_form():
             if not app.busy and stub.calls: break
         resp = app.assistant.last_response
         assert '```json {.tool}' in resp and 'Done.' in resp
-        from fastllm.chat import fmt2hist
+        from aidialog.msg_parts import fmt2hist
         msgs = fmt2hist(resp)   # the stored form round-trips
         assert any(p.type == PartType.tool_result for m in msgs for p in m.content)
     asyncio.run(go())


### PR DESCRIPTION
Imports move to `aidialog.msg_parts` and `aidialog.dialog` for the model layer, with pins raised to `aidialog>=0.0.3` and `llmsurgery>=0.0.8`.