### PR TITLE
Emit OSC 8 hyperlinks and fix inline styling in list items

### DIFF
--- a/ipyai/mdrich.py
+++ b/ipyai/mdrich.py
@@ -10,15 +10,18 @@ from rich.text import Text
 INLINE = {'strong': 'bold', 'em': 'italic', 'code': 'cyan', 'del': 'strike',
           'a': 'underline bright_blue', 'mark': 'reverse'}
 
+def _elem(c, t, style=''):
+    nm = getattr(c, 'name', None)
+    if nm == '#text': return t.append(c.text, style=style or None)
+    if nm == 'br': return t.append('\n')
+    sty = f"{style} {INLINE.get(nm, '')}".strip()
+    href = nm == 'a' and (c.attrs or {}).get('href')
+    if href: sty = f'{sty} link {href}'
+    _inline(c, t, sty)
+    if href: t.append(f' ({href})', style='dim')
+
 def _inline(node, t, style=''):
-    for c in node.children:
-        nm = getattr(c, 'name', None)
-        if nm == '#text': t.append(c.text, style=style or None)
-        elif nm == 'br': t.append('\n')
-        else:
-            sty = f"{style} {INLINE.get(nm, '')}".strip()
-            _inline(c, t, sty)
-            if nm == 'a' and (c.attrs or {}).get('href'): t.append(f" ({c.attrs['href']})", style='dim')
+    for c in node.children: _elem(c, t, style)
     return t
 
 def _find(el, name):
@@ -46,7 +49,7 @@ def _list(el, ordered, depth=0):
                 t.append('\n')
                 t.append(_list(c, nm == 'ol', depth + 1))
             elif nm == '#text': t.append(c.text)
-            else: _inline(c, t)
+            else: _elem(c, t)
         i += 1
     return t
 

--- a/tests/test_mdrich.py
+++ b/tests/test_mdrich.py
@@ -26,8 +26,16 @@ def test_md_blocks():
     assert bs[0].plain == '# Title'
     assert any(s.style and 'bold' in str(s.style) for s in bs[1].spans)
     assert 'a link (http://x.com)' in bs[1].plain
+    assert any(s.style and 'link http://x.com' in str(s.style) for s in bs[1].spans)  # OSC 8: links must be real, not costume
     assert isinstance(bs[2], Syntax) and bs[2].code == 'print(1)'
     assert '• one' in bs[3].plain and '  • nested' in bs[3].plain
     assert bs[4].plain.startswith('│ quoted')
     assert 'a │ b' in bs[5].plain and '1 │ 2' in bs[5].plain
     assert all(hasattr(b, '__rich_console__') or isinstance(b, Text) for b in bs)
+
+def test_list_inline():
+    bs = md_blocks('- [docxlite](https://pypi.org/p/docxlite) - read docx\n- has **bold** text')
+    t = bs[0]
+    assert 'docxlite (https://pypi.org/p/docxlite)' in t.plain
+    assert any(s.style and 'link https://pypi.org/p/docxlite' in str(s.style) for s in t.spans)
+    assert any(s.style and 'bold' in str(s.style) and t.plain[s.start:s.end] == 'bold' for s in t.spans)


### PR DESCRIPTION
Markdown links rendered as styled text only: the `a` style gave labels a blue underline but no `link` attribute, so no OSC 8 escape reached the terminal and labels were not clickable. Links now carry `link <href>`, so terminals (and tmux 3.4+ with the hyperlinks terminal-feature) make the label itself openable, including when teleprint's no-wrap crop truncates the visible URL.

Separately, list items lost all inline styling: `_list` passed each inline element to `_inline`, which styles the children of what it receives, so the element's own tag never hit the `INLINE` map and links/bold/etc rendered as plain text inside lists. The element handling now lives in `_elem`, shared by `_inline` and `_list`.

The dim `(href)` suffix stays as-is: it keeps destinations visible on terminals without hyperlink support.