### PR TITLE
Run `py` as a real cell, add startup.py, and stamp sessions for kernel-side tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ Config lives under `XDG_CONFIG_HOME/ipyai/`: `config.json` and `sysp.txt` (the s
 
 Every key is also a CLI flag for one launch: `ipyai --model anthropic/claude-sonnet-4-6 --think h`. Run `ipyai --help` for the full list; `--think` accepts `l`/`m`/`h`/`x`.
 
+An optional `startup.py` in the same directory runs inside every kernel ipyai owns, at seeding, with `__file__` bound (the same contract as clikernel's `~/.config/clikernel/startup.py`): put the imports and aliases you want every session to start with there. A failure in it names the file and stops the launch. Attached kernels (`-k`) are taken as found and do not run it.
+
 ## Development
 
 See [DEV.md](DEV.md).

--- a/ipyai/assistant.py
+++ b/ipyai/assistant.py
@@ -162,6 +162,7 @@ class Assistant:
             if warn: parts.insert(0, warn)
             tools = ((await self.tools.openai_schemas()) or None) if self.tools else None
             ns = _BridgeNS(self.tools) if tools else {}
+            if self.bridge: self.bridge.aim_info = self.aim_info
             chat = self._make_chat(self.model, self.sp, tools=tools, ns=ns, hist=hist)
             stream = await chat(parts, stream=True, think=self.think or None, max_steps=21)
         except BaseException:

--- a/ipyai/bridge.py
+++ b/ipyai/bridge.py
@@ -1,29 +1,32 @@
 "Wire the kernel bridge to a live gateway client: seed the tool layer, return (bridge, registry)."
 from .kernel_bridge import KernelBridge
 from .tooling import ToolRegistry
+from . import config
 
 PYTHON_TOOL_SRC = '''
 async def py(code:str):  # `py`, the solveit name (codex reserves the function name `python` model-side)
-    "Execute `code` in the user's live IPython session; returns captured output, the result repr, and any error."
-    from IPython.utils.capture import capture_output
+    "Execute `code` as a cell in the user's live IPython session; its printed text, results, errors, and images come back as the user would see them."
     ip = get_ipython()
-    tc = ip.transform_cell(code)
-    with capture_output() as cap: res = await ip.run_cell_async(code, store_history=False, transformed_cell=tc)
-    parts = [cap.stdout, cap.stderr]
-    parts += [o.data.get('text/plain', '') for o in cap.outputs]  # the displayed result lands here under capture
-    if res.result is not None and not cap.outputs: parts.append(repr(res.result))
-    err = res.error_in_exec or res.error_before_exec
-    if err is not None: parts.append(f'{type(err).__name__}: {err}')
-    return '\\n'.join(p for p in parts if p) or 'OK'
+    await ip.run_cell_async(code, store_history=False, transformed_cell=ip.transform_cell(code))
 '''
 
 SEED_SRC = "get_ipython().extension_manager.load_extension('ipykernel_helper.core')"
 
+def _startup_src(path):
+    "The startup file's source wrapped so `__file__` is bound to its path during the run, and absent after (clikernel's shape)"
+    return f'''__file__ = {str(path)!r}
+try: exec(compile({path.read_text()!r}, __file__, 'exec'))
+finally: del __file__'''
+
 async def setup_tools(client):
-    "Seed a live kernel (ipykernel_helper services + the `py` tool + the custom tool imports) and return (bridge, registry)."
+    """Seed a live kernel and return (bridge, registry): ipykernel_helper services, the `py` tool, the user's
+    `config.STARTUP_PATH` (if present; a failure there names the file and stops the launch), then the custom tool imports."""
     bridge = KernelBridge(client)
     for src in (SEED_SRC, PYTHON_TOOL_SRC):
         try: await bridge._exec(src)
         except Exception: pass
-    await bridge.seed_tools(skip=('py', 'python'))
+    if config.STARTUP_PATH.exists():
+        try: await bridge._exec(_startup_src(config.STARTUP_PATH), timeout=60)   # startup files import the tooling stack
+        except RuntimeError as e: raise RuntimeError(f'{config.STARTUP_PATH}: {e}') from None
+    await bridge.seed_tools(skip=('py',))
     return bridge, ToolRegistry(bridge)

--- a/ipyai/cli.py
+++ b/ipyai/cli.py
@@ -452,12 +452,19 @@ class App:
             rows = list_sessions()
             if len(rows) == 1: self.resume_session(rows[0][0])
             elif rows: self.picker = rows[:9]  # the startup picker paints as an over transient once run() starts
-        if self.assistant.session is None: self.assistant.session = Session()
+        if self.assistant.session is None:
+            self.assistant.session = Session()
+            await self._stamp_session()
         a = self.assistant
         a.dlg.meta['ipyai'] = {**a.dlg.meta.get('ipyai', {}), 'kernel_id': self.k.kid}
         if load is not None:
             self._job_note(self.load_dialog(load))   # the one ack: the comm path's ack arrives as magic output instead
             await self.run_loaded()
+
+    async def _stamp_session(self):
+        """Name the session file in the kernel's environment (`LLMDOJO_HOST_ID`), so kernel-side tooling that keys
+        state to the conversation (llmdojo's doc-state) keys it to this session, across resumes and kernel restarts."""
+        await self.assistant.bridge._exec(f"import os; os.environ['LLMDOJO_HOST_ID'] = {self.assistant.session.path.stem!r}")
 
     def _on_comm(self, mt, c):
         "%ipyai lands here (via KernelSession.on_comm): track the comm, ack each command by request id."
@@ -561,6 +568,7 @@ class App:
         a.dlg = dlg
         a.dlg.meta['ipyai'] = {**a.dlg.meta.get('ipyai', {}), 'kernel_id': self.k.kid}
         a.session = Session(path=path)
+        self.comp.spawn(self._stamp_session(), name='stamp')
 
     def load_dialog(self, path):
         """Import a Dialog .ipynb (%ipyai save's output, or any notebook) as the session model. Nothing is

--- a/ipyai/config.py
+++ b/ipyai/config.py
@@ -11,6 +11,7 @@ DEFAULT_PROMPT_MODE = False
 CONFIG_DIR = xdg_config_home()/'ipyai'
 CONFIG_PATH = CONFIG_DIR/'config.json'
 SYSP_PATH = CONFIG_DIR/'sysp.txt'
+STARTUP_PATH = CONFIG_DIR/'startup.py'   # run in every owned kernel at seeding, `__file__` bound, like clikernel's startup.py
 
 DEFAULT_SP = """You are an AI assistant running inside terminal IPython through ipyai.
 

--- a/ipyai/kernel.py
+++ b/ipyai/kernel.py
@@ -17,10 +17,10 @@ class KernelSession:
         self.on_comm = None   # host-side comm handler: (msg_type, content) for comm traffic seen on iopub
         self.on_stdin = None  # async (prompt, password) -> str, answering kernel input_requests
 
-    async def start(self, kernel=''):
+    async def start(self, kernel='', cwd=None, env=None):
         """Create an owned kernel (closed on exit), or attach to `kernel` by id prefix (taken as
-        found: not seeded, never stopped by us). Owned kernels start in our cwd and environment;
-        ownership is `connect`'s: it stamps `kc.owned`, honored at close."""
+        found: not seeded, never stopped by us). Owned kernels start in `cwd` (ours if None) with
+        `env` laid over our environment; ownership is `connect`'s: it stamps `kc.owned`, honored at close."""
         self.mgr = JupyAsyncMultiKernelManager(self.url)
         try: ks = await self.mgr.list_kernels()   # reachability and auth fail here, loudly
         except Exception as e: raise ConnectionError(f'no rustygate gateway at {self.url} (start one with `rustygate`): {e}') from e
@@ -28,7 +28,7 @@ class KernelSession:
             kid = first(k['id'] for k in ks if k['id'].startswith(kernel))
             if not kid: raise ValueError(f'no kernel matching {kernel!r} on {self.url}: {[k["id"][:8] for k in ks]}')
             self.kc = await JupyAsyncKernelClient.connect(self.url, kernel=kid)
-        else: self.kc = await JupyAsyncKernelClient.connect(self.url, cwd=os.getcwd(), env=dict(os.environ))
+        else: self.kc = await JupyAsyncKernelClient.connect(self.url, cwd=str(cwd or os.getcwd()), env=dict(os.environ, **(env or {})))
         self.kid, self.owned = self.kc.kernel_id, self.kc.owned
         if self.owned:   # seed the REPL services (sig_help etc.); attached kernels are taken as found
             try: await self.kc.reply("get_ipython().extension_manager.load_extension('ipykernel_helper.core')",

--- a/ipyai/kernel_bridge.py
+++ b/ipyai/kernel_bridge.py
@@ -1,5 +1,5 @@
 "Kernel-facing bridge: tool discovery, tool calls, and variable reads over a `JupyAsyncKernelClient` (whose eval family does the wire work)."
-import asyncio, json
+import json
 from aidialog.dialog import Message
 from aidialog.hist import output_parts, merge_media
 from aidialog.msg_parts import FullResponse, ToolResponse
@@ -22,7 +22,6 @@ class KernelBridge:
         self._schemas = None
         self._names = None
         self.aim_info = None   # model capability dict gating images in `py` results; the Assistant sets it each turn
-        self._run_lock = asyncio.Lock()   # one `py` cell at a time on this client (see `run_py`)
 
     async def _exec(self, code, *, timeout=_EXEC_TIMEOUT):
         cts = (await self.client.reply(code, silent=True, store_history=False, timeout=timeout))["content"]
@@ -69,11 +68,11 @@ class KernelBridge:
     async def run_py(self, code):
         """The `py` tool: run the model's `code` as a plain cell, the same path as a user cell (so the kernel sees
         exactly the model's code, and nothing is captured kernel-side), and render the nbformat outputs for the
-        model the way solveit does: `ai_output` text, images as media parts gated by `aim_info`. Calls serialize
-        on `_run_lock`: fastllm runs a turn's tool calls in parallel, and two `Run` streams on one client would
-        take each other's reply and idle messages. `store_history=False` keeps the model's cells out of the
-        user's `In` history, and is what kernel-side rules use to tell the model's cells from the user's."""
-        async with self._run_lock: outs = await self.client.run(code, store_history=False)
+        model the way solveit does: `ai_output` text, images as media parts gated by `aim_info`. fastllm runs a
+        turn's tool calls in parallel, so the kernel queues them; `stop_on_error=False` keeps one call's error from
+        aborting the rest. `store_history=False` keeps the model's cells out of the user's `In` history, and is
+        what kernel-side rules use to tell the model's cells from the user's."""
+        outs = await self.client.run(code, store_history=False, stop_on_error=False)
         m = Message(code, output=outs)
         res = merge_media(m.ai_output, output_parts(m, self.aim_info))
         return res if isinstance(res, str) else ToolResponse(res)

--- a/ipyai/kernel_bridge.py
+++ b/ipyai/kernel_bridge.py
@@ -1,10 +1,12 @@
 "Kernel-facing bridge: tool discovery, tool calls, and variable reads over a `JupyAsyncKernelClient` (whose eval family does the wire work)."
-import json
+import asyncio, json
+from aidialog.dialog import Message
+from aidialog.hist import output_parts, merge_media
+from aidialog.msg_parts import FullResponse, ToolResponse
 
 
-# `py` is the ipyaing kernel tool (the solveit name; codex reserves `python` model-side); `python` remains
-# discoverable for legacy kernels where the safepyrun extension seeds it. Only one is ever defined at a time.
-CUSTOM_TOOL_NAMES = ("py", "python", "bash", "start_bgterm", "write_stdin", "close_bgterm", "lnhashview_file", "exhash_file", "list_pyskills")
+# `py` is the ipyaing kernel tool (the solveit name; codex reserves `python` model-side)
+CUSTOM_TOOL_NAMES = ("py", "bash", "start_bgterm", "write_stdin", "close_bgterm", "lnhashview_file", "exhash_file", "list_pyskills")
 _SEED_IMPORTS = dict(bash="from safecmd import bash", start_bgterm="from ptymini.bg import start_bgterm",
     write_stdin="from ptymini.bg import write_stdin", close_bgterm="from ptymini.bg import close_bgterm",
     lnhashview_file="from exhash import lnhashview_file", exhash_file="from exhash import exhash_file",
@@ -14,11 +16,13 @@ _TOOL_TIMEOUT = 600
 
 
 class KernelBridge:
-    "Gives ToolRegistry a namespace-shaped interface over the kernel; silent executes, nothing in history."
+    "Gives ToolRegistry a namespace-shaped interface over the kernel: silent executes for reads and tool calls (nothing in history), except `py`, which runs as a plain cell."
     def __init__(self, client):
         self.client = client
         self._schemas = None
         self._names = None
+        self.aim_info = None   # model capability dict gating images in `py` results; the Assistant sets it each turn
+        self._run_lock = asyncio.Lock()   # one `py` cell at a time on this client (see `run_py`)
 
     async def _exec(self, code, *, timeout=_EXEC_TIMEOUT):
         cts = (await self.client.reply(code, silent=True, store_history=False, timeout=timeout))["content"]
@@ -31,7 +35,7 @@ class KernelBridge:
         return list(r) if isinstance(r, list) else []
 
     async def seed_tools(self, skip=()):
-        "Import the custom tool names (other than py/python, which are defined by the host)."
+        "Import the custom tool names (other than py, which is defined by the host)."
         skip = set(skip)
         for stmt in (_SEED_IMPORTS[n] for n in CUSTOM_TOOL_NAMES if n in _SEED_IMPORTS and n not in skip):
             try: await self._exec(stmt)
@@ -54,15 +58,24 @@ class KernelBridge:
     async def call_tool(self, name, args=None):
         names = await self.available_names()
         if name not in names: raise NameError(f"{name!r} is not defined in the kernel namespace")
+        if name == 'py': return await self.run_py(args['code'])
         await self._exec(f"_ipyai_r = await call_tool(globals()[{name!r}], {(args or {})!r})", timeout=_TOOL_TIMEOUT)
         full_e = "any(c.__name__=='FullResponse' for c in type(_ipyai_r).__mro__)"
         exprs = await self.client.eval_exprs(vs=['_ipyai_r', full_e])
         res = exprs.get('_ipyai_r')
         text = res if isinstance(res, str) else json.dumps(res, ensure_ascii=False, default=str)
-        if exprs.get(full_e) is True:
-            from aidialog.msg_parts import FullResponse
-            return FullResponse(text)
-        return text
+        return FullResponse(text) if exprs.get(full_e) is True else text
+
+    async def run_py(self, code):
+        """The `py` tool: run the model's `code` as a plain cell, the same path as a user cell (so the kernel sees
+        exactly the model's code, and nothing is captured kernel-side), and render the nbformat outputs for the
+        model the way solveit does: `ai_output` text, images as media parts gated by `aim_info`. Calls serialize
+        on `_run_lock`: fastllm runs a turn's tool calls in parallel, and two `Run` streams on one client would
+        take each other's reply and idle messages."""
+        async with self._run_lock: outs = await self.client.run(code)
+        m = Message(code, output=outs)
+        res = merge_media(m.ai_output, output_parts(m, self.aim_info))
+        return res if isinstance(res, str) else ToolResponse(res)
 
     async def read_var(self, name):
         "Value of live expression `name` (`foo` or `foo.bar(...)`); an `<error .../>` string when it raises."

--- a/ipyai/kernel_bridge.py
+++ b/ipyai/kernel_bridge.py
@@ -71,8 +71,9 @@ class KernelBridge:
         exactly the model's code, and nothing is captured kernel-side), and render the nbformat outputs for the
         model the way solveit does: `ai_output` text, images as media parts gated by `aim_info`. Calls serialize
         on `_run_lock`: fastllm runs a turn's tool calls in parallel, and two `Run` streams on one client would
-        take each other's reply and idle messages."""
-        async with self._run_lock: outs = await self.client.run(code)
+        take each other's reply and idle messages. `store_history=False` keeps the model's cells out of the
+        user's `In` history, and is what kernel-side rules use to tell the model's cells from the user's."""
+        async with self._run_lock: outs = await self.client.run(code, store_history=False)
         m = Message(code, output=outs)
         res = merge_media(m.ai_output, output_parts(m, self.aim_info))
         return res if isinstance(res, str) else ToolResponse(res)

--- a/ipyai/kernel_bridge.py
+++ b/ipyai/kernel_bridge.py
@@ -3,7 +3,10 @@ import json
 from aidialog.dialog import Message
 from aidialog.hist import output_parts, merge_media
 from aidialog.msg_parts import FullResponse, ToolResponse
+from fastcore.nbio import render_text
 
+
+TB_MAXLEN = 180   # most characters shown per traceback line in `py` results, clikernel's budget
 
 # `py` is the ipyaing kernel tool (the solveit name; codex reserves `python` model-side)
 CUSTOM_TOOL_NAMES = ("py", "bash", "start_bgterm", "write_stdin", "close_bgterm", "lnhashview_file", "exhash_file", "list_pyskills")
@@ -68,13 +71,13 @@ class KernelBridge:
     async def run_py(self, code):
         """The `py` tool: run the model's `code` as a plain cell, the same path as a user cell (so the kernel sees
         exactly the model's code, and nothing is captured kernel-side), and render the nbformat outputs for the
-        model the way solveit does: `ai_output` text, images as media parts gated by `aim_info`. fastllm runs a
-        turn's tool calls in parallel, so the kernel queues them; `stop_on_error=False` keeps one call's error from
-        aborting the rest. `store_history=False` keeps the model's cells out of the user's `In` history, and is
-        what kernel-side rules use to tell the model's cells from the user's."""
+        model: `render_text` (tagged when a cell has several outputs, tracebacks capped), the same text clikernel
+        shows, plus images as media parts gated by `aim_info`. fastllm runs a turn's tool calls in parallel, so the
+        kernel queues them; `stop_on_error=False` keeps one call's error from aborting the rest. `store_history=False`
+        keeps the model's cells out of the user's `In` history, and is what kernel-side rules use to tell the
+        model's cells from the user's."""
         outs = await self.client.run(code, store_history=False, stop_on_error=False)
-        m = Message(code, output=outs)
-        res = merge_media(m.ai_output, output_parts(m, self.aim_info))
+        res = merge_media(render_text(outs, tb_maxlen=TB_MAXLEN), output_parts(Message(code, output=outs), self.aim_info))
         return res if isinstance(res, str) else ToolResponse(res)
 
     async def read_var(self, name):

--- a/ipyai/kernel_bridge.py
+++ b/ipyai/kernel_bridge.py
@@ -69,14 +69,8 @@ class KernelBridge:
         return FullResponse(text) if exprs.get(full_e) is True else text
 
     async def run_py(self, code):
-        """The `py` tool: run the model's `code` as a plain cell, the same path as a user cell (so the kernel sees
-        exactly the model's code, and nothing is captured kernel-side), and render the nbformat outputs for the
-        model: `render_text` (tagged when a cell has several outputs, tracebacks capped), the same text clikernel
-        shows, plus images as media parts gated by `aim_info`. fastllm runs a turn's tool calls in parallel, so the
-        kernel queues them; `stop_on_error=False` keeps one call's error from aborting the rest. `store_history=False`
-        keeps the model's cells out of the user's `In` history, and is what kernel-side rules use to tell the
-        model's cells from the user's."""
-        outs = await self.client.run(code, store_history=False, stop_on_error=False)
+        "The `py` tool: run `code` as a plain cell and render its outputs as clikernel does (tagged text, capped tracebacks, images gated by `aim_info`)"
+        outs = await self.client.run(code, store_history=False, stop_on_error=False)   # no history: kernel rules tell model cells from the user's; an error must not abort parallel calls queued behind it
         res = merge_media(render_text(outs, tb_maxlen=TB_MAXLEN), output_parts(Message(code, output=outs), self.aim_info))
         return res if isinstance(res, str) else ToolResponse(res)
 

--- a/ipyai/tooling.py
+++ b/ipyai/tooling.py
@@ -1,10 +1,11 @@
 "Shared tool registry + local namespace bridge. Kernel-backed bridge lives in kernel_bridge.py."
 import inspect, json
 
+from aidialog.msg_parts import ToolResponse
 from .kernel_bridge import CUSTOM_TOOL_NAMES
 
 
-def _result_text(res): return res if isinstance(res, str) else json.dumps(res, ensure_ascii=False, default=str)
+def _result_text(res): return res if isinstance(res, (str, ToolResponse)) else json.dumps(res, ensure_ascii=False, default=str)
 
 
 class LocalBridge:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 license = {text = "Apache-2.0"}
 authors = [{name = "Jeremy Howard", email = "info@answer.ai"}]
-dependencies = ["fastcore>=1.12.31", "ipython>=9", "teleprint", "jupyasyncclient>=0.2.5", "ipymini", "rich", "safepyrun",
+dependencies = ["fastcore>=1.12.31", "ipython>=9", "teleprint", "jupyasyncclient>=0.2.8", "ipymini", "rich", "safepyrun",
     "python-fastllm>=0.0.38", "aidialog>=0.0.8", "fastllm-claude-code>=0.0.7", "safecmd", "pyskills", "pillow"]
 
 [project.scripts]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@ import os, tempfile
 import pytest, pytest_asyncio
 
 import ipyai.config as config
-from ipyai.kernel_bridge import CUSTOM_TOOL_NAMES, KernelBridge
+from ipyai.bridge import setup_tools
 
 
 _IPYTHONDIR_SESSION = None
@@ -29,23 +29,13 @@ def temp_config_paths(tmp_path, monkeypatch):
     monkeypatch.setattr(config, "CONFIG_DIR", cfg)
     monkeypatch.setattr(config, "CONFIG_PATH", cfg/"config.json")
     monkeypatch.setattr(config, "SYSP_PATH", cfg/"sysp.txt")
+    monkeypatch.setattr(config, "STARTUP_PATH", cfg/"startup.py")
     yield
 
 
-_KERNEL_BOOTSTRAP = ("from IPython import get_ipython\n"
-    "_ip = get_ipython()\n"
-    "try: _ip.extension_manager.load_extension('ipykernel_helper.core')\n"
-    "except Exception: pass\n"
-    "try: _ip.extension_manager.load_extension('safepyrun')\n"
-    "except Exception: pass\n")
-
-
 async def _prepare_kernel_bridge(client):
-    bridge = KernelBridge(client)
-    await bridge._exec(_KERNEL_BOOTSTRAP)
-    present = set(await bridge.present_names(CUSTOM_TOOL_NAMES))
-    await bridge.seed_tools(skip=present)
-    await bridge.available_names(force=True)
+    "Seed the test kernel exactly as the app does (`setup_tools`): ipykernel_helper, the `py` tool, the custom tool imports."
+    bridge, _ = await setup_tools(client)
     return bridge
 
 

--- a/tests/test_bridge_session.py
+++ b/tests/test_bridge_session.py
@@ -55,11 +55,12 @@ async def test_start_cwd_env(gateway, tmp_path):
 
 
 async def test_py_concurrent_calls(gateway):
-    "Parallel `py` calls from one model turn serialize on the kernel: each gets its own result instead of stealing the other's reply messages."
+    "Parallel `py` calls from one model turn each get their own result, and one call's error does not abort the ones queued behind it."
     async with KernelSession(url=gateway) as k:
         _, tools = await setup_tools(k.kc)
-        calls = (tools.call_text('py', dict(code=c)) for c in ['y = 6*7', 'y', '1+1'])
-        assert await asyncio.wait_for(asyncio.gather(*calls), 20) == ['', '42', '2']
+        calls = (tools.call_text('py', dict(code=c)) for c in ['y = 6*7', '1/0', 'y', '1+1'])
+        res = await asyncio.wait_for(asyncio.gather(*calls), 20)
+        assert 'ZeroDivisionError' in res[1] and [res[0], *res[2:]] == ['', '42', '2']
 
 
 def test_session_files(tmp_path, monkeypatch):

--- a/tests/test_bridge_session.py
+++ b/tests/test_bridge_session.py
@@ -21,6 +21,7 @@ async def test_bridge_and_writeback(gateway):
         out = await tools.call_text('py', {'code': 'zz = 6*7\nprint("side effect")\nzz'})
         assert 'side effect' in out and '42' in out
         assert await bridge.read_var('zz') == 42  # the tool ran in the USER'S namespace
+        assert 'zz = 6*7\nprint("side effect")\nzz' not in await bridge.read_var('In')  # model cells stay out of the user's history (and that is how kernel-side rules tell them apart)
         err = await tools.call_text('py', {'code': '1/0'})
         assert 'ZeroDivisionError' in err and 'division by zero' in err
         img = await tools.call_text('py', {'code': 'from IPython.display import Image, display\nfrom aidialog.dialog import tiny_png\ndisplay(Image(data=tiny_png))'})

--- a/tests/test_bridge_session.py
+++ b/tests/test_bridge_session.py
@@ -19,7 +19,7 @@ async def test_bridge_and_writeback(gateway):
         names = await tools.names()
         assert 'py' in names
         out = await tools.call_text('py', {'code': 'zz = 6*7\nprint("side effect")\nzz'})
-        assert 'side effect' in out and '42' in out
+        assert '<stdout>\nside effect\n</stdout>' in out and '<execute_result>\n42\n</execute_result>' in out  # tagged, so the model can tell a print from a value
         assert await bridge.read_var('zz') == 42  # the tool ran in the USER'S namespace
         assert 'zz = 6*7\nprint("side effect")\nzz' not in await bridge.read_var('In')  # model cells stay out of the user's history (and that is how kernel-side rules tell them apart)
         err = await tools.call_text('py', {'code': '1/0'})

--- a/tests/test_bridge_session.py
+++ b/tests/test_bridge_session.py
@@ -1,5 +1,5 @@
 "Integration: the KernelBridge against a live gateway ipymini, and session-file persistence."
-import pytest
+import asyncio, pytest
 from ipyai.kernel import KernelSession
 from ipyai.bridge import setup_tools
 from ipyai.assistant import LAST_RESPONSE
@@ -7,10 +7,13 @@ from ipyai.session import Session, list_sessions, resolve_session
 from ipyai.history import History
 from aidialog.dialog import Dialog
 from aidialog.ipynb import read_ipynb
+from aidialog.msg_parts import ToolResponse, InputImage
+import ipyai.config as config
+from ipyai.kernel_bridge import KernelBridge
 
 
 async def test_bridge_and_writeback(gateway):
-    "Silent kernel-side exec: the py tool runs live code, set_vars lands LAST_RESPONSE for the user."
+    "The py tool runs the model's code as a plain cell, so its outputs come back as the user would see them: text, tracebacks, and images; set_vars lands LAST_RESPONSE for the user."
     async with KernelSession(url=gateway) as k:
         bridge, tools = await setup_tools(k.kc)
         names = await tools.names()
@@ -18,12 +21,44 @@ async def test_bridge_and_writeback(gateway):
         out = await tools.call_text('py', {'code': 'zz = 6*7\nprint("side effect")\nzz'})
         assert 'side effect' in out and '42' in out
         assert await bridge.read_var('zz') == 42  # the tool ran in the USER'S namespace
+        err = await tools.call_text('py', {'code': '1/0'})
+        assert 'ZeroDivisionError' in err and 'division by zero' in err
+        img = await tools.call_text('py', {'code': 'from IPython.display import Image, display\nfrom aidialog.dialog import tiny_png\ndisplay(Image(data=tiny_png))'})
+        assert isinstance(img, ToolResponse) and any(isinstance(p, InputImage) for p in img.content)
         bridge.set_vars(**{LAST_RESPONSE: 'the reply text'})
         assert await bridge.read_var(LAST_RESPONSE) == 'the reply text'
         # a normal cell still renders normally after bridge traffic (no iopub leakage)
         outs = []
         await k.run('print("clean")', outs.append)
         assert any('clean' in o.get('text', '') for o in outs if o['output_type'] == 'stream')
+
+
+async def test_startup_file(gateway):
+    "An owned kernel runs `config.STARTUP_PATH` at seeding with `__file__` bound, the way clikernel runs its startup.py."
+    config.STARTUP_PATH.write_text('startup_ran = 7\nstartup_file = __file__\n')
+    async with KernelSession(url=gateway) as k:
+        bridge, _ = await setup_tools(k.kc)
+        assert await bridge.read_var('startup_ran') == 7
+        assert await bridge.read_var('startup_file') == str(config.STARTUP_PATH)
+
+
+async def test_start_cwd_env(gateway, tmp_path):
+    "`start(cwd=, env=)` places an owned kernel: it starts in that directory with those entries over our environment."
+    k = await KernelSession(url=gateway).start(cwd=tmp_path, env=dict(IPYAI_TEST_MARK='yes'))
+    try:
+        bridge = KernelBridge(k.kc)
+        await bridge._exec('import os')
+        assert await bridge.read_var('os.getcwd()') == str(tmp_path)
+        assert await bridge.read_var('os.environ["IPYAI_TEST_MARK"]') == 'yes'
+    finally: await k.close()
+
+
+async def test_py_concurrent_calls(gateway):
+    "Parallel `py` calls from one model turn serialize on the kernel: each gets its own result instead of stealing the other's reply messages."
+    async with KernelSession(url=gateway) as k:
+        _, tools = await setup_tools(k.kc)
+        calls = (tools.call_text('py', dict(code=c)) for c in ['y = 6*7', 'y', '1+1'])
+        assert await asyncio.wait_for(asyncio.gather(*calls), 20) == ['', '42', '2']
 
 
 def test_session_files(tmp_path, monkeypatch):

--- a/tests/test_kernel_dispatch.py
+++ b/tests/test_kernel_dispatch.py
@@ -14,17 +14,17 @@ async def test_bridge_runspython_and_reads_vars(kernel_bridge):
     assert vals == {"x": 41, "y": 42}
 
     names = await kernel_bridge.available_names(force=True)
-    assert "python" in names, f"python missing from {names}"
+    assert "py" in names, f"py missing from {names}"
 
-    result = await kernel_bridge.call_tool("python", dict(code="2 + 3"))
+    result = await kernel_bridge.call_tool("py", dict(code="2 + 3"))
     assert "5" in result
 
     bash_res = await kernel_bridge.call_tool("bash", dict(cmd="printf 'x\\n'", as_dict=True))
     assert "x" in bash_res, f"bool tool arg should be marshalled to Python True: {bash_res!r}"
 
     schemas = await kernel_bridge.schemas()
-    python_schema = next(s for s in schemas if s["function"]["name"] == "python")
-    assert "parameters" in python_schema["function"]
+    py_schema = next(s for s in schemas if s["function"]["name"] == "py")
+    assert "parameters" in py_schema["function"]
 
 
 async def test_call_tool_uses_longer_timeout_than_probe_exec(kernel_bridge, monkeypatch):


### PR DESCRIPTION
## What

- **`py` runs as a plain cell.** The tool no longer wraps the model's code in `capture_output`; it goes through `client.run(..., store_history=False, stop_on_error=False)`, and the nbformat outputs are rendered with `render_text` (tagged per-output, tracebacks capped at 180 chars) plus image parts gated by the model's `aim_info`. The kernel now sees exactly the model's code, results come back as the user would see them, and parallel tool calls in one turn no longer abort each other.
- **Model cells stay out of `In`.** `store_history=False` keeps the model's cells out of the user's history, and is the signal kernel-side rules use to tell model cells from user cells.
- **Optional `startup.py`.** `XDG_CONFIG_HOME/ipyai/startup.py` runs in every kernel ipyai owns, at seeding, with `__file__` bound — the same contract as clikernel's startup file. A failure stops the launch. Attached kernels (`-k`) are taken as found and skip it.
- **`KernelSession.start(cwd=, env=)`.** Owned kernels can be placed in a directory with extra environment entries laid over ours.
- **Session stamping.** `LLMDOJO_HOST_ID` is set in the kernel to the session file stem on start and on resume, so kernel-side tooling that keys state to the conversation (llmdojo's doc-state) survives resumes and kernel restarts.
- **Dropped the legacy `python` tool name.** Only `py` is defined now; tests and seeding follow.

## Testing

- Tests seed via `setup_tools`, matching the app's real path instead of a bespoke bootstrap.
- New integration coverage: startup file execution and `__file__` binding, `start(cwd=, env=)`, concurrent `py` calls with an error in the middle, and `py` returning stdout/result tags, tracebacks, and images.

**NB:** Concurrent runs come from `jupyasyncclient>=0.2.8` (the shared `jupywire` router); the pin is bumped in this PR. The earlier client-side fix (jupyasyncclient#15) is superseded and closed.