### PR TITLE
run_cell is now an async generator, and bridge reads no longer jump the kernel queue

### DIFF
--- a/ipyai/cli.py
+++ b/ipyai/cli.py
@@ -304,7 +304,8 @@ class App:
         self.cell_outputs = []
         self.paint()
         m = self.assistant.add_cell(code) if self.assistant is not None else None   # the cell exists before it runs: its id tags the execute
-        try: await self.k.run_cell(m.id if m is not None else f'cell{rtoken_hex(4)}', code, self.on_out)
+        try:
+            async for out in self.k.run_cell(m.id if m is not None else f'cell{rtoken_hex(4)}', code): self.on_out(out)
         finally:
             if self.assistant is not None: self.assistant.finish_cell(m, self.cell_outputs)
             self.cell_outputs = None
@@ -597,7 +598,8 @@ class App:
         execution must wait for idle or it would deadlock."""
         codes, self._load_codes = self._load_codes, []
         while self.k.busy: await asyncio.sleep(0.05)
-        for mid, code in codes: await self.k.run_cell(mid, code, self._silent_out)
+        for mid, code in codes:
+            async for out in self.k.run_cell(mid, code): self._silent_out(out)
         self.paint()
 
     def _silent_out(self, c):

--- a/ipyai/kernel.py
+++ b/ipyai/kernel.py
@@ -58,29 +58,19 @@ class KernelSession:
         c = m['content']
         return self.on_stdin(c.get('prompt', ''), c.get('password', False))
 
-    async def run_cell(self, cid, code, on_output=None, allow_stdin=None, **kw):
-        """Execute `code` tagged as cell `cid` (msg_id `{cid}.{token}`): its messages stream through
-        `run`'s callback as they arrive, and the call returns the nbformat outputs after reply and idle.
+    async def run_cell(self, cid, code, allow_stdin=None, **kw):
+        """Execute `code` tagged as cell `cid` (msg_id `{cid}.{token}`), yielding each nbformat output
+        as it arrives. Comm traffic goes to `on_comm`, and every message to the `on_cell_msg` observer.
         Several cells can be in flight at once; each collects only its own traffic."""
         if allow_stdin is None: allow_stdin = self.on_stdin is not None
         stdin = self._answer_stdin if allow_stdin and self.on_stdin is not None else None
-        outs = []
-        def _msg(m):
-            if self.on_cell_msg is not None:
-                try: self.on_cell_msg(cid, m)
-                except Exception: log.exception('on_cell_msg failed')
-            typ = m['msg_type']
-            if typ in OUTPUT_MSGS:
-                out = msg2out(m)
-                outs.append(out)
-                if on_output is not None:
-                    try: on_output(out)
-                    except Exception: log.exception('on_output failed')
-            elif typ in COMM_MSGS and self.on_comm is not None: self.on_comm(typ, m['content'])
         self.busy = True
         try:
-            await self.kc.run(code, msg_id=f'{cid}.{rtoken_hex(4)}', on_output=_msg, on_stdin=stdin, **kw)
-            return outs
+            async for m in self.kc.run(code, msg_id=f'{cid}.{rtoken_hex(4)}', on_stdin=stdin, **kw):
+                if self.on_cell_msg is not None: self.on_cell_msg(cid, m)
+                typ = m['msg_type']
+                if typ in OUTPUT_MSGS: yield msg2out(m)
+                elif typ in COMM_MSGS and self.on_comm is not None: self.on_comm(typ, m['content'])
         finally: self.busy = False
 
     async def interrupt(self): await self.mgr.interrupt_kernel(self.kid)

--- a/ipyai/kernel_bridge.py
+++ b/ipyai/kernel_bridge.py
@@ -71,15 +71,15 @@ class KernelBridge:
 
     async def run_py(self, code):
         "The `py` tool: run `code` as a cell tagged `py{token}` through the session pump, rendered as clikernel does (tagged text, capped tracebacks, images gated by `aim_info`)"
-        outs = await self.session.run_cell(f'py{rtoken_hex(4)}', code, allow_stdin=False, store_history=False, stop_on_error=False)   # no history: kernel rules tell model cells from the user's; an error must not abort parallel calls queued behind it
+        outs = [o async for o in self.session.run_cell(f'py{rtoken_hex(4)}', code, allow_stdin=False, store_history=False, stop_on_error=False)]   # no history: kernel rules tell model cells from the user's; an error must not abort parallel calls queued behind it
         res = merge_media(render_text(outs, tb_maxlen=TB_MAXLEN), output_parts(Message(code, output=outs), self.aim_info))
         return res if isinstance(res, str) else ToolResponse(res)
 
     async def read_var(self, name):
         "Value of live expression `name` (`foo` or `foo.bar(...)`); an `<error .../>` string when it raises."
-        return (await self.client.eval_exprs(vs=[name])).get(name)
+        return (await self.client.eval_exprs(vs=[name], priority=False)).get(name)
 
-    async def read_vars(self, names): return await self.client.eval_exprs(vs=list(names))
+    async def read_vars(self, names): return await self.client.eval_exprs(vs=list(names), priority=False)
 
     def set_vars(self, **vals):
         "Assign values into the kernel's user namespace, silently."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 license = {text = "Apache-2.0"}
 authors = [{name = "Jeremy Howard", email = "info@answer.ai"}]
-dependencies = ["fastcore>=1.12.31", "ipython>=9", "teleprint", "jupyasyncclient>=0.2.8", "ipymini", "rich", "safepyrun",
+dependencies = ["fastcore>=1.12.31", "ipython>=9", "teleprint", "jupyasyncclient>=0.2.10", "ipymini", "rich", "safepyrun",
     "python-fastllm>=0.0.38", "aidialog>=0.0.8", "fastllm-claude-code>=0.0.7", "safecmd", "pyskills", "pillow"]
 
 [project.scripts]

--- a/tests/test_bridge_session.py
+++ b/tests/test_bridge_session.py
@@ -29,8 +29,7 @@ async def test_bridge_and_writeback(gateway):
         bridge.set_vars(**{LAST_RESPONSE: 'the reply text'})
         assert await bridge.read_var(LAST_RESPONSE) == 'the reply text'
         # a normal cell still renders normally after bridge traffic (no iopub leakage)
-        outs = []
-        await k.run_cell('cellZ', 'print("clean")', outs.append)
+        outs = [o async for o in k.run_cell('cellZ', 'print("clean")')]
         assert any('clean' in o.get('text', '') for o in outs if o['output_type'] == 'stream')
 
 

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -115,12 +115,12 @@ async def test_stop_and_resume():
     app = App(tty, history=None)
     async with app.k:
         app.paint()
-        app.comp.on_bytes(b'!sleep 30\r')
-        await _until(lambda: app.fg_job is not None)
+        app.comp.on_bytes(b"!sh -c 'echo go; exec sleep 30'\r")
+        await _until(lambda: app.fg_job is not None and 'go' in app.fg_job[1].contents())  # the child printed: it exists and owns the terminal, so ^Z cannot land on bash instead
         app.shell.write(b'\x1a')           # ^Z via the pty line discipline
         await _until(lambda: app.fg_job is None)         # the stop bounced us back to the prompt
         app.comp.on_bytes(b'!fg\r')
-        await _until(lambda: app.fg_job is not None)
+        await _until(lambda: app.fg_job is not None and 'sleep' in app.fg_job[1].contents())  # fg reported the job: it has been resumed into the foreground
         app.shell.write(b'\x03')           # ^C the resumed child
         await _until(lambda: app.fg_job is None)
 

--- a/tests/test_kernel_existing.py
+++ b/tests/test_kernel_existing.py
@@ -13,8 +13,7 @@ async def test_attach_existing_kernel_without_shutdown(gateway):
     sb = KernelBridge(att.kc)
     assert await sb.read_var('hidden') == 'walnut'   # live state is the point of attaching
     assert await sb.read_var('q') == 7
-    outs = []
-    await att.run_cell('cellY', "print('post-attach')", outs.append)
+    outs = [o async for o in att.run_cell('cellY', "print('post-attach')")]
     assert any('post-attach' in o.get('text', '') for o in outs if o['output_type'] == 'stream')
     await att.close()   # attached: the kernel must survive our close
     assert await owner.mgr.is_alive(owner.kid), "kernel must still be alive after attached-client close"

--- a/tests/test_kernel_lifecycle.py
+++ b/tests/test_kernel_lifecycle.py
@@ -30,14 +30,13 @@ async def test_spawn_seed_pump_shutdown(gateway):
     types = [mt for cid, mt in got if cid == 'cellA']
     assert {'stream', 'execute_input', 'execute_result'} <= set(types), f'cell traffic not routed: {got}'
     assert all(cid == 'cellA' for cid, mt in got), f'untagged traffic leaked: {got}'
-    outs = []
-    ret = await ks.run_cell('cellB', "'mine'", outs.append)   # a live tagged cell: streamed and returned
-    assert 'mine' in str(outs) and outs == ret
+    outs = [o async for o in ks.run_cell('cellB', "'mine'")]   # a live tagged cell, streamed
+    assert 'mine' in str(outs)
     assert {cid for cid, mt in got} == {'cellA', 'cellB'}, f'unexpected cell ids: {got}'
 
     async def answer(prompt, password): return 'blue'   # the app's handler shape (cli._on_stdin)
     ks.on_stdin = answer
-    outs = await ks.run_cell('cellC', "print('got', input('fav? '))")
+    outs = [o async for o in ks.run_cell('cellC', "print('got', input('fav? '))")]
     assert 'got blue' in str(outs), f'stdin round trip failed: {outs}'
 
     kid = ks.kid

--- a/tests/test_magic.py
+++ b/tests/test_magic.py
@@ -25,7 +25,7 @@ async def test_ipyai_magic_e2e():
     tty, app = _mk_app()
     async with app.k:
         app.paint()
-        await app.k.run_cell(f'cell{rtoken_hex(4)}', '%load_ext ipyai.magic')  # what attach_assistant execs
+        async for _ in app.k.run_cell(f'cell{rtoken_hex(4)}', '%load_ext ipyai.magic'): pass  # what attach_assistant execs
         app.comp.on_bytes(b'%ipyai\r')
         await _settle(app, lambda: 'suggest_model = cm' in tty.term.contents())
         assert 'think = l' in tty.term.contents()
@@ -51,7 +51,7 @@ async def test_ipyai_magic_assignment():
     tty, app = _mk_app()
     async with app.k:
         app.paint()
-        await app.k.run_cell(f'cell{rtoken_hex(4)}', '%load_ext ipyai.magic')
+        async for _ in app.k.run_cell(f'cell{rtoken_hex(4)}', '%load_ext ipyai.magic'): pass
         app.comp.on_bytes(b'x = %ipyai think s\r')
         await _settle(app, lambda: not app.k.busy and app.assistant.think == 's')
         assert await app.k.kc.eval('str(x)', _call=False) == 'think = s'
@@ -61,8 +61,8 @@ async def test_ipyai_magic_no_host():
     tty, app = _mk_app()
     async with app.k:
         app.paint()
-        await app.k.run_cell(f'cell{rtoken_hex(4)}', '%load_ext ipyai.magic')
-        await app.k.run_cell(f'cell{rtoken_hex(4)}', 'import ipyai.magic as _m; _m._TIMEOUT = 0.5')
+        async for _ in app.k.run_cell(f'cell{rtoken_hex(4)}', '%load_ext ipyai.magic'): pass
+        async for _ in app.k.run_cell(f'cell{rtoken_hex(4)}', 'import ipyai.magic as _m; _m._TIMEOUT = 0.5'): pass
         app.k.on_comm = None  # nobody home
         app.comp.on_bytes(b'%ipyai model haiku\r')
         await _settle(app, lambda: 'no ipyai host attached' in tty.term.contents())


### PR DESCRIPTION
`KernelSession.run_cell` yields each nbformat output as it arrives, instead of taking an `on_output` callback and returning a list. Handlers run in the loop body, so their exceptions reach the caller and the `log.exception` guards are gone. The REPL and `run_loaded` stream; `run_py` collects. `KernelBridge.read_var` and `read_vars` pass `priority=False`, so a bridge read can no longer overtake a queued `set_vars` push. `test_stop_and_resume` sends ^Z and ^C only after the child's own output shows it owns the terminal, closing a race where SIGTSTP reached bash instead. The jupyasyncclient floor moves to 0.2.10.